### PR TITLE
Use string format to format strings

### DIFF
--- a/bwtester/bwtestclient/bwtestclient.go
+++ b/bwtester/bwtestclient/bwtestclient.go
@@ -306,8 +306,7 @@ func main() {
 		Check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.FormatInt(int64(clientCCAddr.IA.I), 10) + "-" +
-		strconv.Itoa(int(clientCCAddr.IA.A)) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", clientCCAddr.IA.I, clientCCAddr.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	snet.Init(clientCCAddr.IA, sciondAddr, dispatcherAddr)
 

--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -98,7 +98,7 @@ func runServer(serverCCAddrStr string) {
 		LogFatal("Unable to start server", "err", err)
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(serverCCAddr.IA.I)) + "-" + strconv.FormatInt(int64(serverCCAddr.IA.A), 10) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", serverCCAddr.IA.I, serverCCAddr.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	log.Info("Starting server")
 	snet.Init(serverCCAddr.IA, sciondAddr, dispatcherAddr)

--- a/camerapp/imagefetcher/imagefetcher.go
+++ b/camerapp/imagefetcher/imagefetcher.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/snet"
@@ -189,7 +188,7 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(local.IA.I)) + "-" + strconv.FormatInt(int64(local.IA.A), 10) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	snet.Init(local.IA, sciondAddr, dispatcherAddr)
 	udpConnection, err = snet.DialSCION("udp4", local, remote)

--- a/camerapp/imageserver/imageserver.go
+++ b/camerapp/imageserver/imageserver.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -130,7 +129,7 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(server.IA.I)) + "-" + strconv.FormatInt(int64(server.IA.A), 10) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", server.IA.I, server.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	snet.Init(server.IA, sciondAddr, dispatcherAddr)
 

--- a/sensorapp/sensorfetcher/sensorfetcher.go
+++ b/sensorapp/sensorfetcher/sensorfetcher.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"strconv"
 
 	"github.com/scionproto/scion/go/lib/snet"
 )
@@ -57,7 +56,7 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(local.IA.I)) + "-" + strconv.FormatInt(int64(local.IA.A), 10) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	snet.Init(local.IA, sciondAddr, dispatcherAddr)
 

--- a/sensorapp/sensorserver/sensorserver.go
+++ b/sensorapp/sensorserver/sensorserver.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -91,7 +90,7 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(server.IA.I)) + "-" + strconv.FormatInt(int64(server.IA.A), 10) + ".sock"
+	sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", server.IA.I, server.IA.A)
 	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	snet.Init(server.IA, sciondAddr, dispatcherAddr)
 

--- a/webapp/tests/imgtest/imgclient/img-test-client.go
+++ b/webapp/tests/imgtest/imgclient/img-test-client.go
@@ -9,7 +9,6 @@ import (
     "github.com/scionproto/scion/go/lib/snet"
     "io/ioutil"
     "log"
-    "strconv"
     "time"
 )
 
@@ -186,7 +185,7 @@ func main() {
         check(fmt.Errorf("Error, server address needs to be specified with -s"))
     }
 
-    sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(local.IA.I)) + "-" + strconv.Itoa(int(local.IA.A)) + ".sock"
+    sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
     dispatcherAddr := "/run/shm/dispatcher/default.sock"
     snet.Init(local.IA, sciondAddr, dispatcherAddr)
     udpConnection, err = snet.DialSCION("udp4", local, remote)

--- a/webapp/tests/imgtest/imgserver/img-test-server.go
+++ b/webapp/tests/imgtest/imgserver/img-test-server.go
@@ -127,7 +127,7 @@ func main() {
         check(fmt.Errorf("Error, server address needs to be specified with -s"))
     }
 
-    sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(server.IA.I)) + "-" + strconv.Itoa(int(server.IA.A)) + ".sock"
+    sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", server.IA.I, server.IA.A)
     dispatcherAddr := "/run/shm/dispatcher/default.sock"
     snet.Init(server.IA, sciondAddr, dispatcherAddr)
 

--- a/webapp/tests/statstest/statsclient/stats-test-client.go
+++ b/webapp/tests/statstest/statsclient/stats-test-client.go
@@ -55,7 +55,7 @@ func main() {
         check(fmt.Errorf("Error, server address needs to be specified with -s"))
     }
 
-    sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(local.IA.I)) + "-" + strconv.Itoa(int(local.IA.A)) + ".sock"
+    sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
     dispatcherAddr := "/run/shm/dispatcher/default.sock"
     snet.Init(local.IA, sciondAddr, dispatcherAddr)
 

--- a/webapp/tests/statstest/statsserver/stats-test-server.go
+++ b/webapp/tests/statstest/statsserver/stats-test-server.go
@@ -89,7 +89,7 @@ func main() {
         check(fmt.Errorf("Error, server address needs to be specified with -s"))
     }
 
-    sciondAddr := "/run/shm/sciond/sd" + strconv.Itoa(int(server.IA.I)) + "-" + strconv.Itoa(int(server.IA.A)) + ".sock"
+    sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", server.IA.I, server.IA.A)
     dispatcherAddr := "/run/shm/dispatcher/default.sock"
     snet.Init(server.IA, sciondAddr, dispatcherAddr)
 


### PR DESCRIPTION
Doing a FormatInt(int64(someUint64)) on a uint64 still overflows, using a format string instead works on all platforms.