### PR TITLE
Fix sciond path

### DIFF
--- a/bwtester/bwtestserver/bwtestserver.go
+++ b/bwtester/bwtestserver/bwtestserver.go
@@ -55,8 +55,9 @@ var (
 	serverCCAddr    *snet.Addr
 	err             error
 	CCConn          *snet.Conn
-	sciondAddr      *string
+	sciondPath      *string
 	sciondFromIA    *bool
+	dispatcherPath  *string
 )
 
 func main() {
@@ -67,8 +68,10 @@ func main() {
 	flag.StringVar(&serverCCAddrStr, "s", "", "Server SCION Address")
 	id := flag.String("id", "bwtester", "Element ID")
 	logDir := flag.String("log_dir", "./logs", "Log directory")
-	sciondAddr = flag.String("sciond", "", "Path to sciond socket")
+	sciondPath = flag.String("sciond", "", "Path to sciond socket")
 	sciondFromIA = flag.Bool("sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
+	dispatcherPath = flag.String("dispatcher", "/run/shm/dispatcher/default.sock",
+		"Path to dispatcher socket")
 	flag.Parse()
 
 	// Setup logging
@@ -105,19 +108,15 @@ func runServer(serverCCAddrStr string) {
 	}
 
 	if *sciondFromIA {
-		if *sciondAddr != "" {
+		if *sciondPath != "" {
 			LogFatal("Only one of -sciond or -sciondFromIA can be specified")
 		}
-		*sciondAddr = sciond.GetDefaultSCIONDPath(&serverCCAddr.IA)
-	} else if *sciondAddr == "" {
-		*sciondAddr = sciond.GetDefaultSCIONDPath(nil)
+		*sciondPath = sciond.GetDefaultSCIONDPath(&serverCCAddr.IA)
+	} else if *sciondPath == "" {
+		*sciondPath = sciond.GetDefaultSCIONDPath(nil)
 	}
-	// sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%s.sock", serverCCAddr.IA.I, serverCCAddr.IA.A.FileFmt())
-	sciondAddrStr := "/run/shm/sciond/default.sock"
-
-	dispatcherAddr := "/run/shm/dispatcher/default.sock"
 	log.Info("Starting server")
-	snet.Init(serverCCAddr.IA, sciondAddrStr, dispatcherAddr)
+	snet.Init(serverCCAddr.IA, *sciondPath, *dispatcherPath)
 
 	ci := strings.LastIndex(serverCCAddrStr, ":")
 	if ci < 0 {

--- a/camerapp/imagefetcher/imagefetcher.go
+++ b/camerapp/imagefetcher/imagefetcher.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
@@ -157,8 +158,11 @@ func main() {
 	startTime := time.Now()
 
 	var (
-		clientAddress string
-		serverAddress string
+		clientAddress  string
+		serverAddress  string
+		sciondPath     string
+		sciondFromIA   bool
+		dispatcherPath string
 
 		err    error
 		local  *snet.Addr
@@ -169,7 +173,10 @@ func main() {
 
 	flag.StringVar(&clientAddress, "c", "", "Client SCION Address")
 	flag.StringVar(&serverAddress, "s", "", "Server SCION Address")
-
+	flag.StringVar(&sciondPath, "sciond", "", "Path to sciond socket")
+	flag.BoolVar(&sciondFromIA, "sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
+	flag.StringVar(&dispatcherPath, "dispatcher", "/run/shm/dispatcher/default.sock",
+		"Path to dispatcher socket")
 	flag.Parse()
 
 	// Create SCION UDP socket
@@ -188,10 +195,15 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	//sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
-	sciondAddr := "/run/shm/sciond/sciond.sock"
-	dispatcherAddr := "/run/shm/dispatcher/default.sock"
-	snet.Init(local.IA, sciondAddr, dispatcherAddr)
+	if sciondFromIA {
+		if sciondPath != "" {
+			log.Fatal("Only one of -sciond or -sciondFromIA can be specified")
+		}
+		sciondPath = sciond.GetDefaultSCIONDPath(&local.IA)
+	} else if sciondPath == "" {
+		sciondPath = sciond.GetDefaultSCIONDPath(nil)
+	}
+	snet.Init(local.IA, sciondPath, dispatcherPath)
 	udpConnection, err = snet.DialSCION("udp4", local, remote)
 	check(err)
 

--- a/camerapp/imageserver/imageserver.go
+++ b/camerapp/imageserver/imageserver.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sciond"
 )
 
 const (
@@ -108,7 +109,10 @@ func main() {
 	go HandleImageFiles()
 
 	var (
-		serverAddress string
+		serverAddress  string
+		sciondPath     string
+		sciondFromIA   bool
+		dispatcherPath string
 
 		err    error
 		server *snet.Addr
@@ -118,6 +122,10 @@ func main() {
 
 	// Fetch arguments from command line
 	flag.StringVar(&serverAddress, "s", "", "Server SCION Address")
+	flag.StringVar(&sciondPath, "sciond", "", "Path to sciond socket")
+	flag.BoolVar(&sciondFromIA, "sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
+	flag.StringVar(&dispatcherPath, "dispatcher", "/run/shm/dispatcher/default.sock",
+		"Path to dispatcher socket")
 	flag.Parse()
 
 	// Create the SCION UDP socket
@@ -129,11 +137,15 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	//sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", server.IA.I, server.IA.A)
-	sciondAddr := "/run/shm/sciond/sciond.sock"
-	dispatcherAddr := "/run/shm/dispatcher/default.sock"
-	snet.Init(server.IA, sciondAddr, dispatcherAddr)
-
+	if sciondFromIA {
+		if sciondPath != "" {
+			log.Fatal("Only one of -sciond or -sciondFromIA can be specified")
+		}
+		sciondPath = sciond.GetDefaultSCIONDPath(&server.IA)
+	} else if sciondPath == "" {
+		sciondPath = sciond.GetDefaultSCIONDPath(nil)
+	}
+	snet.Init(server.IA, sciondPath, dispatcherPath)
 	udpConnection, err = snet.ListenSCION("udp4", server)
 	check(err)
 

--- a/roughtime/utils/connection.go
+++ b/roughtime/utils/connection.go
@@ -2,14 +2,11 @@ package utils;
 
 import (
     "log"
-    "fmt"
 
     "github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sciond"
 )
 
-func getSciondAddr(scionAddr *snet.Addr)(string){
-    return fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", scionAddr.IA.I, scionAddr.IA.A)
-}
 
 func getDispatcherAddr(scionAddr *snet.Addr)(string){
     return "/run/shm/dispatcher/default.sock"
@@ -23,7 +20,8 @@ func InitSCIONConnection(scionAddressString string)(*snet.Addr, error){
         return nil, err
     }
 
-    err = snet.Init(scionAddress.IA, getSciondAddr(scionAddress), getDispatcherAddr(scionAddress))
+    err = snet.Init(scionAddress.IA, sciond.GetDefaultSCIONDPath(nil),
+    	getDispatcherAddr(scionAddress))
     if err != nil {
         return scionAddress, err
     }

--- a/sensorapp/sensorfetcher/sensorfetcher.go
+++ b/sensorapp/sensorfetcher/sensorfetcher.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sciond"
 )
 
 func check(e error) {
@@ -27,6 +28,9 @@ func main() {
 	var (
 		clientAddress string
 		serverAddress string
+		sciondPath     string
+		sciondFromIA   bool
+		dispatcherPath string
 
 		err    error
 		local  *snet.Addr
@@ -38,6 +42,10 @@ func main() {
 	// Fetch arguments from command line
 	flag.StringVar(&clientAddress, "c", "", "Client SCION Address")
 	flag.StringVar(&serverAddress, "s", "", "Server SCION Address")
+	flag.StringVar(&sciondPath, "sciond", "", "Path to sciond socket")
+	flag.BoolVar(&sciondFromIA, "sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
+	flag.StringVar(&dispatcherPath, "dispatcher", "/run/shm/dispatcher/default.sock",
+		"Path to dispatcher socket")
 	flag.Parse()
 
 	// Create the SCION UDP socket
@@ -56,11 +64,15 @@ func main() {
 		check(fmt.Errorf("Error, server address needs to be specified with -s"))
 	}
 
-	// sciondAddr := fmt.Sprintf("/run/shm/sciond/sd%d-%d.sock", local.IA.I, local.IA.A)
-	sciondAddr := "/run/shm/sciond/default.sock"
-	dispatcherAddr := "/run/shm/dispatcher/default.sock"
-	snet.Init(local.IA, sciondAddr, dispatcherAddr)
-
+	if sciondFromIA {
+		if sciondPath != "" {
+			log.Fatal("Only one of -sciond or -sciondFromIA can be specified")
+		}
+		sciondPath = sciond.GetDefaultSCIONDPath(&local.IA)
+	} else if sciondPath == "" {
+		sciondPath = sciond.GetDefaultSCIONDPath(nil)
+	}
+	snet.Init(local.IA, sciondPath, dispatcherPath)
 	udpConnection, err = snet.DialSCION("udp4", local, remote)
 	check(err)
 


### PR DESCRIPTION
The default sciond path has changed. (#45 )
Update the applications to use the canonical way of getting the sciond
path.
Roughtime needs some additional work to handle it canonically.

Tested:
 - sensorapp
 - bwtester

Not tested:
 - camerapp
 - roughtime
